### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php": ">=8.0",
         "fenguoz/data-types": "^1.0",
         "guzzlehttp/guzzle": "^7.2",
-        "fenguoz/web3.php": "^1.0",
+        "web3p/web3.php": "^1.0",
         "kornrunner/secp256k1": "^0.2",
         "simplito/elliptic-php": "^1.0",
         "ext-json": "*",


### PR DESCRIPTION
You dont really have to use your own fork because of original web3p/web3.php has php ^8.0 in requirements.

If you use both tron-api and the original web3.php (latest update) in one project, there are issues due to incompatibility of class constructors Web3\Providers\HttpProvider.

Please either stop using your outdated fork or update the classes in it to the latest version of web3.php.